### PR TITLE
reload replays button + replay server fix

### DIFF
--- a/LegendaryClient/Windows/CreateCustomGamePage.xaml.cs
+++ b/LegendaryClient/Windows/CreateCustomGamePage.xaml.cs
@@ -94,7 +94,7 @@ namespace LegendaryClient.Windows
                         break;
 
                     default:
-                        gameConfig.GameMap = GameMap.SummonersRift;
+                        gameConfig.GameMap = GameMap.NewSummonersRift;
                         gameConfig.GameMode = "CLASSIC";
                         break;
                 }

--- a/LegendaryClient/Windows/MainPage.xaml.cs
+++ b/LegendaryClient/Windows/MainPage.xaml.cs
@@ -39,9 +39,12 @@ namespace LegendaryClient.Windows
         internal ArrayList gameList;
         internal ArrayList newsList;
         internal static System.Timers.Timer timer = new System.Timers.Timer();
+        internal List<int> curentlyRecording;
+
         public MainPage()
         {
             InitializeComponent();
+            curentlyRecording = new List<int>();
             AppDomain current = AppDomain.CurrentDomain;
             GotPlayerData(Client.LoginPacket);
             SpectatorComboBox.SelectedValue = Client.LoginPacket.CompetitiveRegion;
@@ -488,6 +491,17 @@ namespace LegendaryClient.Windows
                 MMRLabel.Content = "≈" + deserializedJSON["interestScore"];
             }
             catch { MMRLabel.Content = "N/A"; }
+
+            if (curentlyRecording.Contains(GameId))
+            {
+                RecordButton.IsEnabled = false;
+                RecordButton.Content = "Recording...";
+            }
+            else
+            {
+                RecordButton.IsEnabled = true;
+                RecordButton.Content = "Record";
+            }
         }
 
         private void SpectateButton_Click(object sender, RoutedEventArgs e)
@@ -586,6 +600,12 @@ namespace LegendaryClient.Windows
             BaseRegion region = BaseRegion.GetRegion((string)SpectatorComboBox.SelectedValue);
             //region.SpectatorIpAddress, key, gameId, platformId
             var recorder = new ReplayRecorder(region.SpectatorIpAddress + ":8088", gameId, platformId, key);
+            recorder.OnReplayRecorded += () => {
+                curentlyRecording.Remove(gameId);
+            };
+            curentlyRecording.Add(gameId);
+            RecordButton.IsEnabled = false;
+            RecordButton.Content = "Recording...";
         }
 
         private void HoverLabel_MouseDown(object sender, System.Windows.Input.MouseButtonEventArgs e)

--- a/LegendaryClient/Windows/ReplayPage.xaml
+++ b/LegendaryClient/Windows/ReplayPage.xaml
@@ -14,6 +14,7 @@
         <ScrollViewer VerticalScrollBarVisibility="Visible" HorizontalScrollBarVisibility="Disabled" HorizontalAlignment="Left" Margin="0,143,0,0" VerticalAlignment="Stretch" Width="420">
             <StackPanel x:Name="GamePanel" />
         </ScrollViewer>
+        <Button Name="refresh" Content="Refresh Replays" HorizontalAlignment="Left" Margin="425,650,0,0" VerticalAlignment="Top" Width="100" Click="refresh_Click"/>
         <Controls:TextBoxWatermarked x:Name="Command" Text="" TextChanged="Command_TextChanged" HorizontalAlignment="Left" TextWrapping="Wrap" Watermark="Enter username here" VerticalAlignment="Top" Margin="10,49,0,0" Width="330" Height="24"/>
         <Button x:Name="Download" Visibility="Hidden" Click="Download_Click" Content="Download" HorizontalAlignment="Left" VerticalAlignment="Top" Width="75" Margin="345,49,0,0" Height="24" FontSize="11"/>
         <Label x:Name="HintLabel" Content="" Margin="10,78,604,568"/>

--- a/LegendaryClient/Windows/ReplayPage.xaml.cs
+++ b/LegendaryClient/Windows/ReplayPage.xaml.cs
@@ -299,6 +299,11 @@ namespace LegendaryClient.Windows
             string[] details = selectedStats.Difficulty.Split('-');
             Client.LaunchSpectatorGame("127.0.0.1:5651", File.ReadAllText(Path.Combine(Client.ExecutingDirectory, "cabinet", selectedStats.Difficulty, "key")), Convert.ToInt32(details[0]), details[1]);
         }
+
+        private void refresh_Click(object sender, RoutedEventArgs e)
+        {
+            UpdateReplays();
+        }
     }
 
     public class FocusVisualTreeChanger

--- a/PVPNetConnect/RiotObjects/Platform/Game/Map/GameMap.cs
+++ b/PVPNetConnect/RiotObjects/Platform/Game/Map/GameMap.cs
@@ -64,6 +64,17 @@ namespace PVPNetConnect.RiotObjects.Platform.Game.Map
             TotalPlayers = 10
         };
 
+        public static GameMap NewSummonersRift = new GameMap()
+        {
+            Description =
+                "The oldest and most venerated Field of Justice is known as Summoner's Rift.  This battleground is known for the constant conflicts fought between two opposing groups of Summoners.  Traverse down one of three different paths in order to attack your enemy at their weakest point.  Work with your allies to siege the enemy base and destroy their Headquarters!",
+            MapId = 11,
+            DisplayName = "New Summoner's Rift",
+            MinCustomPlayers = 1,
+            Name = "SummonersRift",
+            TotalPlayers = 10
+        };
+
         public static GameMap TheCrystalScar = new GameMap()
         {
             Description =

--- a/ReplayHandler/ReplayHandler.csproj
+++ b/ReplayHandler/ReplayHandler.csproj
@@ -37,6 +37,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />


### PR DESCRIPTION
It should work now, I managed to run replays that seemed to be broken before. I have no idea how to remove those previous commits so I will try to explain them at least. The record button is disabled only for one specific match that is already being recorded (so you don't record one match twice), you can still record 2+ matches simultaneously. Damn, this git thing is weird, sorry :c
